### PR TITLE
Changed all http to https since it causes security blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,5 +90,5 @@
 		CITE/CTS is ©2002–2017 Neel Smith and Christopher Blackwell. This tool for working with images cited via CITE2 URNs is ©2017 by Christopher Blackwell and Mees Gelein. ICT2 is available for use, modification, and distribution under the terms of the <a href="https://opensource.org/licenses/gpl-3.0.html">GPL 3.0</a> license. ICT2 is based on <a href="http://openseadragon.github.io">Openseadragon</a>.
 		</p>
 	</footer>
-	<script type="text/javascript" src="js/ict2.js"></script>
+	<script type="text/javascript" src="js/ict2.js?v=1"></script>
 	</html>

--- a/js/ict2.js
+++ b/js/ict2.js
@@ -2,8 +2,8 @@
 
 var viewer = null
 
-// "http://www.homermultitext.org/iipsrv?DeepZoom=/project/homer/pyramidal/VenA/"
-var defaultServiceUrl = "http://www.homermultitext.org/iipsrv?"
+// "https://www.homermultitext.org/iipsrv?DeepZoom=/project/homer/pyramidal/VenA/"
+var defaultServiceUrl = "https://www.homermultitext.org/iipsrv?"
 var defaultServiceZoomService = "DeepZoom="
 var defaultServicePath = "/project/homer/pyramidal/deepzoom/"
 var defaultServiceSuffix = ".tif"
@@ -203,7 +203,7 @@ function initOpenSeadragon() {
 		crossOriginPolicy: "Anonymous",
 		defaultZoomLevel: 1,
 		tileSources: getTileSources(imgUrn),
-		// tileSources: 'http://www.homermultitext.org/iipsrv?DeepZoom=/project/homer/pyramidal/VenA/VA012RN_0013.tif.dzi',
+		// tileSources: 'https://www.homermultitext.org/iipsrv?DeepZoom=/project/homer/pyramidal/VenA/VA012RN_0013.tif.dzi',
 		minZoomImageRatio: 0.1, // of viewer size
 		immediateRender: true
 	});


### PR DESCRIPTION
Some browsers don't want to load HTTP content on a HTTPS connection. This would be normal, but for some reason some versions of browser still load with only warnings. 

This fix should make it future proof.